### PR TITLE
fix: corrected some typos in first two sections

### DIFF
--- a/lectures/0-notation.tex
+++ b/lectures/0-notation.tex
@@ -17,7 +17,7 @@ Let us enumerate some fundamental sets:
     \item $\mathbb{N} = \{1, 2, 3, \dots\}$ -- a set of natural numbers.
     \item $\mathbb{Z} = \{0, \pm 1, \pm 2, \pm 3, \dots\}$ -- a set of integers.
     \item $\mathbb{Q} = \{\frac{n}{m}: n \in \mathbb{Z}, m \in \mathbb{N}\}$ -- a set of rational numbers.
-    \item $\mathbb{R}$ -- a set of real numbers. Examples: $2.2, -3.9 0.12, 1.4, -6.7, \dots$
+    \item $\mathbb{R}$ -- a set of real numbers. Examples: $2.2, -3.9, 0.12, 1.4, -6.7, \dots$
     \item $\mathbb{R}_{>0}$ -- a set of positive real numbers. Examples: $2.6, 10.4, 100.2$.
     \item $\mathbb{C}$ -- a set of complex numbers\footnote{Complex number is an expression in a form $x+iy$ for $i^2=-1$}. 
     Examples: $1+2i, 5i, -7-5.7i, \dots$.
@@ -166,7 +166,7 @@ the prover while $\mathcal{V}$ denotes the verifier. Such parties are algorithms
 themselves, so we can easily write $y \gets \mathcal{P}(x)$ to denote that 
 the prover, based on $x$, has outputted $y$.
 
-To denote the probability of an event $E$ hapenning, we write $\Pr[E]$. For
+To denote the probability of an event $E$ happening, we write $\Pr[E]$. For
 example, if $E$ is an event of rolling a dice and getting a number $4$, then
 $\Pr[E] = \frac{1}{6}$. To denote the random sampling from the finite set $X$,
 we write $x \leftarrowS X$. For example, $x \leftarrowS \{1,2,3,4,5,6\}$

--- a/lectures/1-1-number-theory.tex
+++ b/lectures/1-1-number-theory.tex
@@ -74,7 +74,7 @@ This theorem allows us to define two new operations. Suppose $a,b,q,r$ are given
 as in the \Cref{th:division}. Then,
 \begin{itemize}
     \item \textbf{Floor Operation} ($\lfloor a/b \rfloor$ or $a \; \text{div} \; b$) is defined
-    as $q$. This operation is a standard \text{div} opeartion commonly used in programming languages.
+    as $q$. This operation is a standard \text{div} operation commonly used in programming languages.
     \item \textbf{Mod Operation} ($a \; \text{mod} \; b$) is defined as $r$. This operation is a standard
 \text{mod} operation commonly used in programming languages. 
 \end{itemize}
@@ -120,7 +120,7 @@ numbers. This is where the concept of the \textbf{greatest common divisor} (or
         \item $d$ is a maximal integer that satisfies the first condition.
     \end{enumerate}
 
-    One might right the above definition more concisely:
+    One might write the above definition more concisely:
     \begin{xequation}
         \gcd(a,b) = \max\{d \in \mathbb{N}: d \mid a \; \text{and} \; d \mid b\}.
     \end{xequation}
@@ -183,7 +183,7 @@ print(gcd(13, 17)) # Output: 1
 
 \end{lstlisting}
 
-However, such an appraoch in the worst-case scenario still requires linear time
+However, such an approach in the worst-case scenario still requires linear time
 in the size of the numbers: for example, when computing $\gcd(n, 1)$. The following lemma will be extensively employed in
 the so-called \textit{Euclidean algorithm}, which will reduce the complexity down
 to logarithmic time.


### PR DESCRIPTION
Typos corrected in `2 Notation` and `3 Introduction to Number Theory` sections:
- page 11: `-3.90.12` to `-3.9, 0.12`
- page 13: `hapenning` to `happening`
- page 16: `opeartion` to `operation`
- page 17: `right` to `write`
- page 18: `appraoch` to `approach`